### PR TITLE
Fix package.json generated by the ccw script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,9 +84,9 @@ Element that represents the SVG element of a cubicon: (e.g. `<path>`, `<circle>`
 
 9. Run `npm link` to link the local repository to store it globally on your machine.
 
-10. Make a new directory somewhere outside the local repo directory. Run `npm link cubecubed` to pull the global codes to the new directory.
+10. Run `npx cubecubed my-workspace` somewhere outside the local repo directory to initialize a scene (make sure you say 'yes' for all of the prompt options).
 
-11. Run `npx cubecubed` to initialize a scene (make sure you say 'yes' for all of the prompt options).
+11. Inside the `my-workspace` folder, run `npm link cubecubed` to pull the global codes to the new directory.
 
 12. Run `npm run dev` again to test the npm package.
 

--- a/ccw.js
+++ b/ccw.js
@@ -67,22 +67,15 @@ const prompt = () => {
             },
         ])
         .then((answers) => {
-            exec(`npm i ${project}`);
-
-            let raw;
-
-            try {
-                raw = readFileSync("package.json");
-            } catch (err) {
-                throw err;
-            }
+            execSync(`npm i ${project}`);
 
             clone();
 
             if (answers["vite"]) {
                 console.log("Installing vite...");
 
-                exec("npm i vite", () => {
+                exec("npm i -D vite", () => {
+                    const raw = readFileSync("package.json").toString();
                     writePackageJson(raw, {
                         key: "scripts",
                         value: {


### PR DESCRIPTION
This PR
- updates the contribution guide to fix the testing instructions. For example, `npx cubecubed` is not a valid command now, so it is replaced with `npx cubecubed my-workspace`.
- fixes the `ccw.js` script to make sure the generated `package.json` file has correct `dependencies` and `devDependencies` fields.

Before the PR, the content of the `package.json` file generated by the `ccw` script is as follows:

```
{
  "name": "my-workspace",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "dev": "vite",
    "build": "vite build",
    "serve": "vite preview"
  },
  "keywords": [],
  "author": "",
  "license": "ISC",
  "dependencies": {
    "cubecubed": "^1.11.0"
  }
}
```

After the PR, the file also contains a `devDependencies` field:

```
{
  "name": "my-workspace",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "dev": "vite",
    "build": "vite build",
    "serve": "vite preview"
  },
  "keywords": [],
  "author": "",
  "license": "ISC",
  "dependencies": {
    "cubecubed": "^1.11.0"
  },
  "devDependencies": {
    "vite": "^3.2.4"
  }
```